### PR TITLE
Fix Radio class and add tests

### DIFF
--- a/src/main/java/ru/netology/services/Radio.java
+++ b/src/main/java/ru/netology/services/Radio.java
@@ -4,9 +4,18 @@ public class Radio {
 
     private int currentStation;
     private int currentVolume;
+    private int maxStation;
+
+    public Radio() {
+        this.maxStation = 9;
+    }
+
+    public Radio(int countStation) {
+        this.maxStation = countStation -1;
+    }
 
     public void nextStation() {
-        if (currentStation >= 9) {
+        if (currentStation >= maxStation) {
             currentStation = 0;
         } else {
             currentStation++;
@@ -15,7 +24,7 @@ public class Radio {
 
     public void prevStation() {
         if (currentStation <= 0) {
-            currentStation = 9;
+            currentStation = maxStation;
         } else {
             currentStation--;
         }
@@ -29,7 +38,7 @@ public class Radio {
         if (newCurrentStation < 0) {
             return;
         }
-        if (newCurrentStation > 9) {
+        if (newCurrentStation > maxStation) {
             return;
         }
         currentStation = newCurrentStation;

--- a/src/test/java/ru/netology/services/RadioTest.java
+++ b/src/test/java/ru/netology/services/RadioTest.java
@@ -44,6 +44,19 @@ public class RadioTest {
     }
 
     @Test
+    public void shouldPrevFromMinStation() {
+        Radio radio = new Radio(10);
+
+        radio.setCurrentStation(0);
+        radio.prevStation();
+
+        int expected = 9;
+        int actual = radio.getCurrentStation();
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
     public void prevFromMaxStation() {
         Radio radio = new Radio();
 
@@ -95,12 +108,46 @@ public class RadioTest {
     }
 
     @Test
+    public void shouldSetStation() {
+        Radio radio = new Radio(10);
+
+        radio.setCurrentStation(8);
+        int expected = 8;
+        int actual = radio.getCurrentStation();
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldSetStationStationMax() {
+        Radio radio = new Radio(10);
+
+        radio.setCurrentStation(10);
+        int expected = 0;
+        int actual = radio.getCurrentStation();
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
     public void setStationMoreMaxStation() {
         Radio radio = new Radio();
 
         radio.setCurrentStation(10);
         radio.nextStation();
         int expected = 1;
+        int actual = radio.getCurrentStation();
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldMoreMaxStation() {
+        Radio radio = new Radio(10);
+
+        radio.setCurrentStation(9);
+        radio.nextStation();
+        int expected = 0;
         int actual = radio.getCurrentStation();
 
         Assertions.assertEquals(expected, actual);


### PR DESCRIPTION
1. Можно задавать количество радиостанций при создании объекта, по умолчанию — 10.
2. Номер текущей радиостанции изменяется в пределах от 0 до количества радиостанций не включительно. То есть если станций 10, то номер последней — 9.
3. Если текущая радиостанция — максимальная, и клиент нажал на кнопку next на пульте, то текущей должна стать нулевая.
4. Если текущая радиостанция — 0, и клиент нажал на кнопку prev на пульте, то текущей должна стать максимальная.
5. Всё так же присутствует сеттер текущей станции.